### PR TITLE
Adds NewPool() and NewPoolWithURL()

### DIFF
--- a/redisurl_test.go
+++ b/redisurl_test.go
@@ -1,18 +1,37 @@
-package redisurl_test
+package redisurl
 
 import (
-	"github.com/soveran/redisurl"
 	"github.com/garyburd/redigo/redis"
 	"testing"
 )
 
 func TestConnect(t *testing.T) {
-	c, err := redisurl.Connect()
+	c, err := Connect()
 
 	if err != nil {
 		t.Errorf("Error returned")
 	}
 
+	pong, err := redis.String(c.Do("PING"))
+
+	if err != nil {
+		t.Errorf("Call to PING returned an error: %v", err)
+	}
+
+	if pong != "PONG" {
+		t.Errorf("Wanted PONG, got %v\n", pong)
+	}
+}
+
+func TestNewPool(t *testing.T) {
+	pool, err := NewPool(3, 200, "240s")
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	c := pool.Get()
+	defer c.Close()
 	pong, err := redis.String(c.Do("PING"))
 
 	if err != nil {


### PR DESCRIPTION
This pull request adds convenience methods for redigo's connection pools, the way redigo itself handles it is really cumbersome.

``` go
pool, _ := NewPool(3, 200, "240s") // Args are "maxIdle", "maxActive" and "idleTimeout"

c := pool.Get()
defer c.Close()
pong, err := redis.String(c.Do("PING"))
```

Unrelated: is there any particular reason for the test to be in it's own package? Feel free to revert that part, I changed it because I prefer to keep them in the package itself and this way doesn't play along with my Go setup.
