### PR TITLE
Update redigo dependency

### DIFF
--- a/redisurl.go
+++ b/redisurl.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 func Connect() (redis.Conn, error) {

--- a/redisurl_test.go
+++ b/redisurl_test.go
@@ -1,9 +1,10 @@
 package redisurl_test
 
 import (
-	"github.com/soveran/redisurl"
-	"github.com/garyburd/redigo/redis"
 	"testing"
+
+	"github.com/gomodule/redigo/redis"
+	"github.com/soveran/redisurl"
 )
 
 func TestConnect(t *testing.T) {


### PR DESCRIPTION
From https://github.com/garyburd/redigo:

```
Future development of Redigo is at github.com/gomodule/redigo. Please submit issues at gomodule/redigo. The repository at github.com/garyburd/redigo will no longer be maintained.
```